### PR TITLE
Call classList.add() with single parameter

### DIFF
--- a/src/Modal.ts
+++ b/src/Modal.ts
@@ -136,7 +136,9 @@ export class Modal {
 
     private createBackDrop() {
         this.backdropElement = document.createElement("div");
-        this.backdropElement.classList.add("modal-backdrop", "fade", "in");
+        this.backdropElement.classList.add("modal-backdrop");
+        this.backdropElement.classList.add("fade");
+        this.backdropElement.classList.add("in");
     }
 
 }


### PR DESCRIPTION
Adding multiple class won't work in IE and other older browsers (Firefox 24- and Chrome 24-)