### PR TITLE
don't stop propagation of click events from content

### DIFF
--- a/src/Modal.ts
+++ b/src/Modal.ts
@@ -34,8 +34,8 @@ export class ModalFooter {
      (keydown.esc)="closeOnEscape ? close() : 0"
      [ngClass]="{ in: isOpened, fade: isOpened }"
      [ngStyle]="{ display: isOpened ? 'block' : 'none' }"
-     (click)="closeOnOutsideClick ? close() : 0">
-    <div [class]="'modal-dialog ' + modalClass" (click)="preventClosing($event)">
+     (click)="backdropClick($event)">
+    <div [class]="'modal-dialog ' + modalClass" #modalContent>
         <div class="modal-content" tabindex="0" *ngIf="isOpened">
             <div class="modal-header">
                 <button *ngIf="!hideCloseButton" type="button" class="close" data-dismiss="modal" [attr.aria-label]="cancelButtonLabel || 'Close'" (click)="close()"><span aria-hidden="true">&times;</span></button>
@@ -105,6 +105,9 @@ export class Modal {
     // Private properties
     // -------------------------------------------------------------------------
 
+    @ViewChild('modalContent')
+    private contentEl: ElementRef;
+
     @ViewChild("modalRoot")
     public modalRoot: ElementRef;
 
@@ -156,6 +159,12 @@ export class Modal {
     // -------------------------------------------------------------------------
     // Private Methods
     // -------------------------------------------------------------------------
+
+    private backdropClick(event: MouseEvent): void {
+        if (this.closeOnOutsideClick === true && !this.contentEl.nativeElement.contains(event.target)) {
+            this.close();
+        }
+    }
 
     public preventClosing(event: MouseEvent) {
         event.stopPropagation();

--- a/src/RouteModal.ts
+++ b/src/RouteModal.ts
@@ -12,8 +12,8 @@ import {Router, ActivatedRoute} from "@angular/router";
      (keydown.esc)="closeOnEscape ? close() : 0"
      [ngClass]="{ in: isOpened, fade: isOpened }"
      [ngStyle]="{ display: isOpened ? 'block' : 'none' }"
-     (click)="closeOnOutsideClick ? close() : 0">
-    <div [class]="'modal-dialog ' + modalClass" (click)="preventClosing($event)">
+     (click)="backdropClick($event)">
+    <div [class]="'modal-dialog ' + modalClass" #modalContent>
         <div class="modal-content" tabindex="0" *ngIf="isOpened">
             <div class="modal-header">
                 <button *ngIf="!hideCloseButton" type="button" class="close" data-dismiss="modal" [attr.aria-label]="cancelButtonLabel || 'Close'" (click)="close()"><span aria-hidden="true">&times;</span></button>
@@ -82,6 +82,9 @@ export class RouteModal implements OnInit, OnDestroy {
     // -------------------------------------------------------------------------
     // Private properties
     // -------------------------------------------------------------------------
+
+    @ViewChild('modalContent')
+    private contentEl: ElementRef;
 
     @ViewChild("modalRoot")
     public modalRoot: ElementRef;
@@ -154,6 +157,12 @@ export class RouteModal implements OnInit, OnDestroy {
     // -------------------------------------------------------------------------
     // Private Methods
     // -------------------------------------------------------------------------
+
+    private backdropClick(event: MouseEvent): void {
+        if (this.closeOnOutsideClick === true && !this.contentEl.nativeElement.contains(event.target)) {
+            this.close();
+        }
+    }
 
     public preventClosing(event: MouseEvent) {
         event.stopPropagation();


### PR DESCRIPTION
For instance when using a dropdown with an outsideClick listener, the click event should not be catched by the modal